### PR TITLE
Add hpos1/hpos2 commands

### DIFF
--- a/Commands/Tools.lua
+++ b/Commands/Tools.lua
@@ -78,6 +78,20 @@ function HandlePos1Command(Split, Player)
 	return true
 end
 
+-----------------------------------------------
+--------------------SETHPOS1-------------------
+-----------------------------------------------
+function HandleHPos1Command(Split, Player)
+	local PlayerName = Player:GetName()
+	OnePlayer[PlayerName] = HPosSelect(Player, Player:GetWorld())
+	if OnePlayer[PlayerName] ~= nil and TwoPlayer[PlayerName] ~= nil then
+		Player:SendMessage(cChatColor.LightPurple .. 'First position set to (' .. OnePlayer[PlayerName].x .. ".0, " .. OnePlayer[PlayerName].y .. ".0, " .. OnePlayer[PlayerName].z .. ".0) (" .. GetSize(Player) .. ").")
+	else
+		Player:SendMessage(cChatColor.LightPurple .. 'First position set to (' .. OnePlayer[PlayerName].x .. ".0, " .. OnePlayer[PlayerName].y .. ".0, " .. OnePlayer[PlayerName].z .. ".0).")
+	end
+	return true
+end
+
 
 -----------------------------------------------
 --------------------SETPOS2--------------------
@@ -85,6 +99,21 @@ end
 function HandlePos2Command(Split, Player)
 	local PlayerName = Player:GetName()
 	TwoPlayer[PlayerName] = Vector3i(math.floor(Player:GetPosX()), math.floor(Player:GetPosY()), math.floor(Player:GetPosZ()))
+	if OnePlayer[PlayerName] ~= nil and TwoPlayer[PlayerName] ~= nil then
+		Player:SendMessage(cChatColor.LightPurple .. 'Second position set to (' .. TwoPlayer[PlayerName].x .. ".0, " .. TwoPlayer[PlayerName].y .. ".0, " .. TwoPlayer[PlayerName].z .. ".0) (" .. GetSize(Player) .. ").")
+	else
+		Player:SendMessage(cChatColor.LightPurple .. 'Second position set to (' .. TwoPlayer[PlayerName].x .. ".0, " .. TwoPlayer[PlayerName].y .. ".0, " .. TwoPlayer[PlayerName].z .. ".0).")
+	end
+	return true
+end
+
+-----------------------------------------------
+--------------------SETHPOS2-------------------
+-----------------------------------------------
+function HandleHPos2Command(Split, Player)
+	local PlayerName = Player:GetName()
+  local target = HPosSelect(Player, Player:GetWorld())
+  TwoPlayer[PlayerName] = HPosSelect(Player, Player:GetWorld())
 	if OnePlayer[PlayerName] ~= nil and TwoPlayer[PlayerName] ~= nil then
 		Player:SendMessage(cChatColor.LightPurple .. 'Second position set to (' .. TwoPlayer[PlayerName].x .. ".0, " .. TwoPlayer[PlayerName].y .. ".0, " .. TwoPlayer[PlayerName].z .. ".0) (" .. GetSize(Player) .. ").")
 	else

--- a/Commands/functions.lua
+++ b/Commands/functions.lua
@@ -200,3 +200,30 @@ function LeftClickCompass(Player, World)
 	cLineBlockTracer.Trace(World, Callbacks, Start.x, Start.y, Start.z, End.x, End.y, End.z)
 	return HasHit
 end
+
+------------------------------------------------
+-- HPOSSELECT ----------------------------------
+------------------------------------------------
+function HPosSelect(Player, World)
+  local hpos = nil
+  local Callbacks = {
+    OnNextBlock = function(X, Y, Z, BlockType, BlockMeta)
+      if BlockType ~= E_BLOCK_AIR and not g_BlockOneHitDig[BlockType] then
+        hpos = Vector3i(X, Y, Z)
+        return true
+      end
+    end
+  };
+
+  local EyePos = Player:GetEyePosition()
+  local LookVector = Player:GetLookVector()
+  LookVector:Normalize()
+
+  local Start = EyePos + LookVector + LookVector;
+  local End = EyePos + LookVector * 150
+  if cLineBlockTracer.Trace(World, Callbacks, Start.x, Start.y, Start.z, End.x, End.y, End.z) then
+    return nil
+  end
+
+  return hpos
+end

--- a/main.lua
+++ b/main.lua
@@ -69,6 +69,8 @@ function Initialize(Plugin)
 	PluginManager:BindCommand("/",	            "worldedit.superpickaxe",              HandleSuperPickCommand,      "")
 	PluginManager:BindCommand("//pos1",         "worldedit.selection.pos",             HandlePos1Command,           " Set position 1")
 	PluginManager:BindCommand("//pos2",         "worldedit.selection.pos",             HandlePos2Command,           " Set position 2")
+	PluginManager:BindCommand("//hpos1",        "worldedit.selection.pos",             HandleHPos1Command,          " Set position 1")
+	PluginManager:BindCommand("//hpos2",        "worldedit.selection.pos",             HandleHPos2Command,          " Set position 2")
 	
 	-- Help commands:
 	PluginManager:BindCommand("/biomelist",	    "worldedit.biomelist",                 HandleBiomeListCommand,      " Gets all biomes available.")


### PR DESCRIPTION
Allow WorldEdit position setting commands using //hpos1 and //hpos2,
which marks the block that is being looked at as the target position
as opposed to the block on which the player is standing.
