### PR TITLE
Allow return of only block type, if no meta is passed

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -26,12 +26,19 @@ function GetBlockTypeMeta(a_BlockString)
 		return BlockID, 0, true
 	end
 	
+	-- Check for block meta
+	local HasMeta = string.find(a_BlockString, ":")
+
 	-- Check if it was a name.
 	local Item = cItem()
 	if (not StringToItem(a_BlockString, Item)) then
 		return false
 	else
-		return Item.m_ItemType, Item.m_ItemDamage
+		if (HasMeta) then
+			return Item.m_ItemType, Item.m_ItemDamage
+		else
+			return Item.m_ItemType, 0, true
+		end
 	end
 end
 


### PR DESCRIPTION
Current problem is you can not count, for example, all chests, if they have different orientations. Fixed that by checking if a_BlockString contains a colon. If it's has no colon return true for TypeOnly.

Example:
`//count chest` - I would expect that all chests are counted, but GetBlockTypeMeta returns by default always the item damage and this is 0, therefore then it's internal `//count chest:0`