### PR TITLE
Implement basic //distr command.

### DIFF
--- a/Commands/Selection.lua
+++ b/Commands/Selection.lua
@@ -69,6 +69,62 @@ end
 
 
 
+function HandleDistrCommand(a_Split, a_Player)
+	-- //distr
+	
+	-- TODO: -d option that separates data values.
+	
+	-- Check the selection:
+	local State = GetPlayerState(a_Player)
+	if not(State.Selection:IsValid()) then
+		a_Player:SendMessage(cChatColor.Rose .. "No selection set")
+		return true
+	end
+	
+	-- Get selection information.
+	local World = a_Player:GetWorld()
+	local Area = cBlockArea()
+	Area:Read(World, State.Selection:GetSortedCuboid())
+	local SizeX, SizeY, SizeZ = Area:GetCoordRange()
+	
+	-- Count the blocks.
+	local TotalCount = Area:GetVolume()
+	local BlockCounts = {}
+	
+	for X = 0, SizeX do
+		for Y = 0, SizeY do
+			for Z = 0, SizeZ do
+				local BlockType = Area:GetRelBlockType(X, Y, Z)
+				BlockCounts[BlockType] = (BlockCounts[BlockType] or 0) + 1
+			end
+		end
+	end
+	
+	-- Generate the output.
+	-- Sort records by count.
+	local SortedBlockCounts, Index = {}, 1
+	for BlockType, BlockCount in pairs(BlockCounts) do
+		SortedBlockCounts[Index] = {Type = BlockType, Count = BlockCount}
+		Index = Index + 1
+	end
+	table.sort(SortedBlockCounts, function(Block1, Block2) return Block1.Count < Block2.Count end)
+	
+	-- Display them.
+	a_Player:SendMessage(cChatColor.LightPurple .. "# total blocks: " .. TotalCount)
+	for _, Block in ipairs(SortedBlockCounts) do
+		local BlockName = ItemTypeToString(Block.Type)
+		local Perc = 100 * Block.Count / TotalCount
+		local Line = string.format("% 7d (%.3f%%) %s #%d", Block.Count, Perc, BlockName, Block.Type)
+		a_Player:SendMessage(cChatColor.LightPurple .. Line)
+	end
+	
+	return true
+end
+
+
+
+
+
 function HandleExpandContractCommand(a_Split, a_Player)
 	-- //expand [Amount] [Direction]
 	-- //contract [Amount] [Direction]

--- a/Info.lua
+++ b/Info.lua
@@ -81,6 +81,14 @@ g_PluginInfo =
 			Category = "Generation",
 		},
 		
+		["//distr"] =
+		{
+			Permission = "worldedit.selection.distr",
+			Handler = HandleDistrCommand,
+			HelpString = " Inspect the block distribution of the current selection.",
+			Category = "Selection",
+		},
+		
 		["//drain"] =
 		{
 			Permission = "worldedit.drain",

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ Commands that give info/help setting the region you have selected.
 
 | Command | Permission | Description |
 | ------- | ---------- | ----------- |
-|//count | worldedit.selection.count |  Count the number of blocks in the region.|
 |//chunk | worldedit.selection.chunk |  Select the chunk you are currently in.|
+|//count | worldedit.selection.count |  Count the number of blocks in the region.|
+|//distr | worldedit.selection.distr |  Inspect the block distribution of the current selection.|
 |//expand | worldedit.selection.expand |  Expand the selection area|
 |//hpos1 | worldedit.selection.pos |  Set position 1 to the position you are looking at.|
 |//hpos2 | worldedit.selection.pos |  Set position 2 to the position you are looking at.|
@@ -224,7 +225,9 @@ Commands that activate a tool. If a tool is activated you can use it by right or
 | worldedit.schematic.load |  | `//schematic load` |  |
 | worldedit.schematic.save |  | `//schematic save` |  |
 | worldedit.scripting.execute |  | `/cs`, `/.s` |  |
+| worldedit.selection.chunk |  | `//chunk` |  |
 | worldedit.selection.count |  | `//count` |  |
+| worldedit.selection.distr |  | `//distr` |  |
 | worldedit.selection.cylinder |  | `//hcyl` |  |
 | worldedit.selection.expand |  | `//expand` |  |
 | worldedit.selection.pos |  | `//hpos2`, `//hpos1`, `//pos1`, `//pos2` |  |


### PR DESCRIPTION
Hi I implemented a basic version of the `//distr` command from WorldEdit.
Basic version because `-c` and `-d` are missing so far but the basic command to count the blocks in a selection works. Now I am not sure if you want to merge it in this state (also again might be that I missed some fancy API methods) but I thought I'd send this pull request anyway.

I also have a little question regarding the permission naming, is the idea to be 100% compatible with Bukkit WorldEdit? Because I now named the `//distr` permission the same way as `//count` (here it's `worldedit.selection.count` while in Bukkit WE it's `worldedit.analysis.count`).