### PR TITLE
Fixed commands related to selection

### DIFF
--- a/Classes/PlayerSelection.lua
+++ b/Classes/PlayerSelection.lua
@@ -250,9 +250,9 @@ end
 function cPlayerSelection:GetSortedCuboid()
 	assert(self:IsValid())
 
-	local SCuboid = cCuboid(self.Cuboid)
+	local SCuboid = self.Cuboid
 	SCuboid:Sort()
-	return SCuboid;
+	return SCuboid
 end
 
 

--- a/Info.lua
+++ b/Info.lua
@@ -6,9 +6,9 @@
 g_PluginInfo =
 {
 	Name = "WorldEdit",
-	Version = 13,
-	DisplayVersion = "0.1.12",
-	Date = "2017-07-12", -- yyyy-mm-dd
+	Version = 14,
+	DisplayVersion = "0.1.13",
+	Date = "2017-08-21", -- yyyy-mm-dd
 	SourceLocation = "https://github.com/cuberite/WorldEdit",
 	Description = [[This plugin allows you to easily manage the world, edit the world, navigate around or get information. It bears similarity to the Bukkit's WorldEdit plugin and aims to have the same set of commands,however, it has no affiliation to that plugin.
 	]],


### PR DESCRIPTION
Commands that requires the player to select an area broke after a recent Cuberite update. This seems to fix the problem.

Fixes #131