### PR TITLE
Cubeset export

### DIFF
--- a/Classes/ClipboardStorage.lua
+++ b/Classes/ClipboardStorage.lua
@@ -1,0 +1,392 @@
+
+-- Schematic.lua
+
+-- Contains classes for saving and loading a clipboard depending on the requested format.
+
+
+
+
+
+--- Default values for cubeset metadata.
+local g_CubesetDefaultValues = 
+{
+	Metadata = 
+	{
+		CubesetFormatVersion = 1,
+		IntendedUse = "SinglePieceStructures",
+		["AllowedBiomes"] = "Plains",
+		["GridSizeX"] = "750",
+		["GridSizeZ"] = "750",
+		["MaxOffsetX"] = "100",
+		["MaxOffsetZ"] = "100",
+	},
+	PiecesMetadata =
+	{
+		IsStarting = "1",
+		MergeStrategy = "msSpongePrint",
+		MoveToGround = "0",
+		ExpandFloorStrategy = "RepeatBottomTillNonAir",
+		VerticalStrategy = "TerrainOrOceanTop|-2",
+		DefaultWeight = "100",
+		AllowedRotations = "7",
+	}
+}
+
+
+
+
+local g_FormatExtensionMap = {
+	["mcedit"] = ".schematic",
+	["cubeset"] = ".cubeset"
+}
+
+
+
+
+cClipboardStorage = {}
+
+
+
+
+
+function cClipboardStorage:new(a_Obj, a_Clipboard)
+	local a_Obj = a_Obj or {}
+	setmetatable(a_Obj, cClipboardStorage)
+	self.__index = self
+
+	self.Clipboard = a_Clipboard;
+	return a_Obj
+end
+
+
+
+
+
+--- Maps the requested format to the right file extension.
+function cClipboardStorage:GetExtension(a_Format)
+	return g_FormatExtensionMap[a_Format] or false;
+end
+
+
+
+
+
+--- Returns a path for the provided file. The extension depends on the requested format.
+function cClipboardStorage:FormatPath(a_FileName, a_Format)
+	local Extension = cClipboardStorage:GetExtension(a_Format);
+	if (not Extension) then
+		return false, "Format not recognized."
+	end
+	return "schematics/" .. a_FileName .. Extension
+end
+
+
+
+
+
+--- Searches for the requested file and loads it into the user's clipboard.
+-- Can load mcedit files and cubeset files.
+function cClipboardStorage:Load(a_FileName, a_Options)
+	local foundPath, foundFormat;
+	for format, extension in pairs(g_FormatExtensionMap) do
+		local path = cClipboardStorage:FormatPath(a_FileName, format);
+		if (cFile:IsFile(path)) then
+			foundPath = path;
+			foundFormat = format;
+			break;
+		end
+	end
+	
+	if (not foundPath) then
+		return false, "File not found.";
+	end
+
+	if (foundFormat == "mcedit") then
+		return self:LoadMCEdit(foundPath);
+	elseif (foundFormat == "cubeset") then
+		return self:LoadCubeset(foundPath, a_Options);
+	end
+end
+
+
+
+
+
+--- Loads the provided file as a schematic file.
+function cClipboardStorage:LoadMCEdit(a_Path)
+	self.Clipboard.Area:LoadFromSchematicFile(a_Path);
+	return true;
+end
+
+
+
+
+
+--- Tries to load the provided file as a cubeset file.
+function cClipboardStorage:LoadCubeset(a_Path, a_Options)
+	local loader, err = loadfile(a_Path);
+	if (not loader) then
+		return false, "Unable to parse cubeset file.";
+	end
+	local env = {}
+	setfenv(loader, env);
+	local success, err = pcall(loader);
+	if (not success) then
+		return false, "Unable to load cubeset file.";
+	end
+
+	if (not env.Cubeset or not env.Cubeset.Metadata) then
+		return false, "Cubeset file doesn't contain any metadata.";
+	end
+	if (env.Cubeset.Metadata.CubesetFormatVersion == 1) then
+		return self:LoadCubesetV1(env, a_Options);
+	else
+		return false, "Unknown Cubeset version.";
+	end
+end
+
+
+
+
+
+--- Loads the provided cubeset environment into the users clipboard.
+function cClipboardStorage:LoadCubesetV1(a_Env, a_Options)
+	local options, err = ParseOptionsToDictionary(a_Options);
+	if (not options) then
+		return false, err
+	end
+	local pieceNr = options.piecenr or 1;
+	local piece = a_Env.Cubeset.Pieces[pieceNr];
+	if (not piece) then
+		return false, "The requested piece in the Cubeset file does not exist."
+	end
+
+	-- Create a dictionary symbol -> block type/meta based on the blockdefinitions.
+	local blockDefinitions = {}
+	for idx, blockDefinition in ipairs(piece.BlockDefinitions) do
+		local split = StringSplitAndTrim(blockDefinition, ":");
+		if (#split ~= 3) then
+			return false, "Block Definitions in cubeset is corrupt at definition nr. " .. idx;
+		end
+		blockDefinitions[split[1]] = {type = split[2], meta = split[3]}
+	end
+
+	-- Set all blocks in the cubeset blockdata to a new blockarea.
+	-- A new blockarea is used so the user's current clipboard isn't corrupted if something is wrong in the cubeset's blockdata.
+	local area = cBlockArea();
+	area:Create(piece.Size.x, piece.Size.y, piece.Size.z);
+	local blockdata = table.concat(piece.BlockData);
+	for y = 0, piece.Size.y - 1 do
+		for z = 0, piece.Size.z - 1 do
+			for x = 0, piece.Size.x - 1 do
+				local index = (x + z * piece.Size.x + y * piece.Size.x * piece.Size.z) + 1 -- Lua is 1-based.
+				local symbol = blockdata:sub(index, index);
+				local definition = blockDefinitions[symbol];
+				if (not definition) then
+					return false, ('Unknown block definition "%s" at (%s, %s, %s) in cubeset file.'):format(symbol, x, y, z)
+				end
+				area:SetRelBlockTypeMeta(x, y, z, definition.type, definition.meta);
+			end
+		end
+	end
+
+	-- Move the new blockarea to the user's clipboard.
+	area:CopyTo(self.Clipboard.Area);
+	return true
+end
+
+
+
+
+
+function cClipboardStorage:Save(a_Name, a_Format, a_Options)
+	local Format = a_Format:lower();
+	local Path, Error = self:FormatPath(a_Name, Format);
+	if (not Path) then
+		return false, Error
+	end
+
+	-- Check if there already is a schematic with that name, and if so if we are allowed to override it.
+	if (not g_Config.Schematics.OverrideExistingFiles and cFile:IsFile(Path)) then
+		return false, "There already is a schematic with that name."
+	end
+
+    if (Format == "mcedit") then
+		return self:SaveMCEdit(Path)
+	elseif (Format == "cubeset") then
+		return self:SaveCubesetV1(Path, a_Name, a_Options)
+	end
+end
+
+
+
+
+
+function cClipboardStorage:SaveMCEdit(a_FileName)
+	self.Clipboard.Area:SaveToSchematicFile(a_FileName)
+	return true;
+end
+
+
+
+
+
+--- Parses an array of key=value strings into an array with objects containing the key and value.
+-- If a name is prefixed with "piece." it's used as metadata of the piece itself, not as metadata of the cubeset file.
+function cClipboardStorage:ParseOptions(a_Options)
+	local output = {}
+	local isXZOption = table.todictionary({"MaxOffset", "GridSize"});
+	for _, option in ipairs(a_Options) do
+		local optionName, value = option:match("^(.-)%=(.-)$")
+		local isPieceOption, name = optionName:match("^(piece%.)(.-)$")
+		name = name or optionName
+		if (isXZOption[name]) then
+			table.insert(output, {isPieceOption = isPieceOption ~= nil, name = name .. "X", value = value})
+			table.insert(output, {isPieceOption = isPieceOption ~= nil, name = name .. "Z", value = value})
+		else
+			table.insert(output, {isPieceOption = isPieceOption ~= nil, name = name, value = value})
+		end
+	end
+	return output
+end
+
+
+
+
+
+--- Saves the current clipboard into a v1 cubeset format in the provided file.
+function cClipboardStorage:SaveCubesetV1(a_FileName, a_StructureName, a_Options)
+	local area = self.Clipboard.Area;
+	local blockdata, definitions = self:GetBlockDefinitions(area);
+	local output = {
+		Metadata = table.merge({}, g_CubesetDefaultValues.Metadata),
+		Pieces =
+		{
+			{
+				Metadata = table.merge({}, g_CubesetDefaultValues.PiecesMetadata),
+				OriginData =
+				{
+					ExportName = a_StructureName,
+					Name = a_StructureName,
+				},
+				Size =
+				{
+					x = area:GetSizeX(),
+					y = area:GetSizeY(),
+					z = area:GetSizeZ(),
+				},
+				Hitbox = 
+				{
+					MinX = 0,
+					MinY = 0,
+					MinZ = 0,
+					MaxX = area:GetSizeX() - 1,
+					MaxY = area:GetSizeY() - 1,
+					MaxZ = area:GetSizeZ() - 1,
+				},
+				StructureBox = 
+				{
+					MinX = 0,
+					MinY = 0,
+					MinZ = 0,
+					MaxX = area:GetSizeX() - 1,
+					MaxY = area:GetSizeY() - 1,
+					MaxZ = area:GetSizeZ() - 1,
+				},
+				Connectors = {},
+				
+				BlockDefinitions =
+				{
+					unpack(definitions)
+				},
+				BlockData = 
+				{
+					unpack(blockdata)
+				}
+			}
+		}
+	};
+
+	-- Allow the user to override the default metadata.
+	for _, option in ipairs(self:ParseOptions(a_Options)) do
+		if (option.isPieceOption) then
+			output.Pieces[1].Metadata[option.name] = option.value;
+		else
+			output.Metadata[option.name] = option.value;
+		end
+	end
+
+	local file = io.open(a_FileName, "w");
+	if (not file) then
+		return false, "Could not open file"
+	end
+	file:write("Cubeset = \n{\n")
+
+	-- Recursive function to dump the Lua table to the output file.
+	local function write(a_Tabs, a_Obj)
+		local prefix = string.rep("\t", a_Tabs);
+		for k, v in pairs(a_Obj) do
+			if (k == "CubesetFormatVersion") then
+				file:write(prefix, k, ' =');
+			elseif (type(k) == "string") then
+				file:write(prefix, '["', k, '"] =');
+			elseif (type(k) == "number") then
+				file:write(prefix, '[', k, '] =');
+			end
+			if (type(v) == "table") then
+				file:write("\n", prefix, "{\n")
+					write(a_Tabs + 1, v);
+				file:write("\n", prefix, "},\n")
+			elseif (type(v) == "string") then
+				file:write(' "', v, '",\n')
+			elseif (type(v) == "number") then
+				file:write(" ", v, ",\n")
+			end
+		end
+	end
+	write(1, output);
+	file:write("}")
+	file:close()
+	return true;
+end
+
+
+
+
+
+--- Parses the provided cBlockArea into an array of blockdata and an array of blockdefinitions.
+function cClipboardStorage:GetBlockDefinitions(a_Area)
+	local symbols = "abcdefghijklnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*,<>/?;[{]}|_-=+~"
+	local currentSymbol = 1;
+
+	-- In order to be similar to the GalExport plugin air always uses '.' and sponges always use 'm'
+	local definitionDictionary = {["0:0"] = ".", ["19:0"] = "m"}
+	local definitions = {".:0:0", "m:19:0"}
+	local blockdata = {}
+	local sizeX, sizeY, sizeZ = a_Area:GetCoordRange();
+
+	for y = 0, sizeY do
+		for z = 0, sizeZ do
+			local blockline = "";
+			for x = 0, sizeX do
+				local blocktype, blockmeta = a_Area:GetRelBlockTypeMeta(x, y, z);
+				local key = blocktype .. ":" .. blockmeta;
+				local symbol = definitionDictionary[key]
+				if (not symbol) then
+					symbol = symbols:sub(currentSymbol, currentSymbol);
+					currentSymbol = currentSymbol + 1;
+					definitionDictionary[key] = symbol;
+					table.insert(definitions, symbol .. ":" .. key);
+				end
+				blockline = blockline .. symbol;
+			end
+			table.insert(blockdata, blockline);
+		end
+	end
+	return blockdata, definitions
+end
+
+
+
+
+

--- a/Classes/PlayerState.lua
+++ b/Classes/PlayerState.lua
@@ -39,10 +39,11 @@ function cPlayerState:new(a_Obj, a_PlayerKey, a_Player)
 
 	-- Initialize the object members to their defaults:
 	local ClientHandle = a_Player:GetClientHandle()
-	a_Obj.Clipboard = cClipboard:new()
 	if (ClientHandle ~= nil) then
 		a_Obj.IsWECUIActivated = ClientHandle:HasPluginChannel("WECUI")
 	end
+	a_Obj.Clipboard = cClipboard:new()
+	a_Obj.ClipboardStorage = cClipboardStorage:new({}, a_Obj.Clipboard);
 	a_Obj.PlayerKey = a_PlayerKey
 	a_Obj.Selection = cPlayerSelection:new({}, a_Obj)
 	a_Obj.UndoStack = cUndoStack:new({}, 10, a_Obj)  -- TODO: Settable Undo depth (2nd param)
@@ -209,5 +210,5 @@ end
 
 
 -- Register the hooks needed:
-cPluginManager.AddHook(cPluginManager.HOOK_PLAYER_DESTROYED,   OnPlayerDestroyed)
-cPluginManager.AddHook(cPluginManager.HOOK_PLUGIN_MESSAGE,     OnPluginMessage)
+cPluginManager:AddHook(cPluginManager.HOOK_PLAYER_DESTROYED,   OnPlayerDestroyed)
+cPluginManager:AddHook(cPluginManager.HOOK_PLUGIN_MESSAGE,     OnPluginMessage)

--- a/Classes/ToolRegistrator.lua
+++ b/Classes/ToolRegistrator.lua
@@ -69,17 +69,23 @@ function cToolRegistrator:BindAbsoluteTools()
 		return true
 	end
 
-	local function OnPlayerRightClick(a_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace)
+	local timeSinceLastRightWand = -math.huge
+	local function RightClickWandItem(a_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace)
 		local Succ, Message = GetPlayerState(a_Player).Selection:SetPos(a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, "Second")
 		if (not Succ) then
 			return false
 		end
 
+		if ((os.clock() - timeSinceLastRightWand) < 0.2) then
+			return;
+		end
+
+		timeSinceLastRightWand = os.clock()
 		a_Player:SendMessage(Message)
 		return true
 	end
 
-	local function OnPlayerLeftClick(a_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace)
+	local function LeftClickWandItem(a_Player, a_BlockX, a_BlockY, a_BlockZ, a_BlockFace)
 		local Succ, Message = GetPlayerState(a_Player).Selection:SetPos(a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, "First")
 		if (not Succ) then
 			return false
@@ -90,9 +96,9 @@ function cToolRegistrator:BindAbsoluteTools()
 	end
 
 	self:BindRightClickTool(g_Config.NavigationWand.Item, RightClickCompassCallback, "thru tool", true)
-	self:BindRightClickTool(g_Config.WandItem,            OnPlayerRightClick, "selection", true)
+	self:BindRightClickTool(g_Config.WandItem,            RightClickWandItem, "selection", true)
 	self:BindLeftClickTool(g_Config.NavigationWand.Item,  LeftClickCompassCallback, "jumpto tool", true)
-	self:BindLeftClickTool(g_Config.WandItem,             OnPlayerLeftClick, "selection", true)
+	self:BindLeftClickTool(g_Config.WandItem,             LeftClickWandItem, "selection", true)
 end
 
 

--- a/LibrariesExpansion/table.lua
+++ b/LibrariesExpansion/table.lua
@@ -35,6 +35,7 @@ function table.merge(a_SrcTable, a_DstTable)
 			end
 		end
 	end
+	return a_SrcTable
 end
 
 

--- a/functions.lua
+++ b/functions.lua
@@ -892,3 +892,20 @@ function HPosSelect(a_Player, a_MaxDistance)
 	end
 	return hpos
 end
+
+
+
+
+
+--- Parses array of key=value strings to dictionary for easy access.
+function ParseOptionsToDictionary(a_Split)
+	local output = {}
+	for idx, value in ipairs(a_Split) do
+		local key, val = value:match("^(.-)%=(.-)$");
+		if (not key) then
+			return false, '"' .. value .. '" could not be parsed.'
+		end
+		output[key] = tonumber(val) or val;
+	end
+	return output
+end


### PR DESCRIPTION
This makes it possible to save your clipboard to the Cubeset format so Cuberite's SinglePieceStructures generator can use it to generate custom structures. By default the `//schematic save` command still uses the mcedit (.schematic) format by default


## Saving

In order to save with the Cubeset format you have to specify that in the command:
```
//schematic save cubeset myfile
```

If you want to override certain settings, like the biomes in which the structure should generate or the size of the grid used to spread out the structure then it's possible to add those options at the end of the command. 
```
//schematic save cubeset myfile AllowedBiomes=Ocean,DeepOcean GridSize=500
```

Certain settings are piece specific in the Cubeset format, like how the piece should be placed on the ground. This can be specified by prefixing the setting with `piece.`. This would look like this:

```
//schematic save cubeset myfile piece.VerticalStrategy=TerrainOrOceanTop|-2
```
It's also possible to load structures with multiple pieces like the netherfortress prefabs.

## Loading

Loading a cubeset file is the same as the mcedit format. The plugin automatically finds the requested file (though it doesn't notice yet if there are two files with the same name but different extensions). If there are multiple pieces in a cubeset file, for example if you load the NetherFortress cubeset file, then it's possible to specify which piece you want by adding `piecenr=<the piece you want>`

```
//schematic load NetherFortress piecenr=6
```


## Using in the world generator

After saving your clipboard to a cubeset file it's possible to load it in the world generator. This is done by copying the file from the `schematics` folder into `Prefabs/SinglePieceStructures` and then enabling it in your world's world.ini file. This is done by adding `SinglePieceStructures: <CubesetFilename>` into your world.ini's Finishers list.
![2023-05-04_13 30 20](https://user-images.githubusercontent.com/1160867/236191723-e682126a-a0d8-4762-9335-fb16b98fe799.png)